### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,10 +15,10 @@ ArduinoOTA	KEYWORD1
 begin	KEYWORD2
 setup	KEYWORD2
 handle	KEYWORD2
-onStart KEYWORD2
-onEnd   KEYWORD2
-onError KEYWORD2
-onProgress KEYWORD2
+onStart	KEYWORD2
+onEnd	KEYWORD2
+onError	KEYWORD2
+onProgress	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords